### PR TITLE
Fixed a build issue on Linux

### DIFF
--- a/gazebo/gui/SpaceNav.cc
+++ b/gazebo/gui/SpaceNav.cc
@@ -23,9 +23,16 @@
 
 #include <boost/bind.hpp>
 #include <gazebo/gazebo_config.h>
+
 #ifdef HAVE_SPNAV
 #include <spnav.h>
-#endif
+
+#ifdef USE_X11
+// Undef a #define Status int that has been created in X11/Xlib.h
+#undef Status
+#endif //USE_X11
+
+#endif //HAVE_SPNAV
 
 #include "gazebo/gui/GuiIface.hh"
 #include "gazebo/gui/SpaceNavPrivate.hh"


### PR DESCRIPTION
X11/Xlib.h is creating a #define that conflicts with the Protobuf
library

solution is to undef the define before including the protobuf headers

X11/Xlib.h: `#define Status int`
google/protobuf/stubs/logging.h: `class Status;`